### PR TITLE
Fix for spinning forever doing a socket recv after serf stops/restarts.

### DIFF
--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -73,7 +73,7 @@ class SerfConnection(object):
         while messages_expected > 0:
             try:
                 buf = self._socket.recv(self._socket_recv_size)
-                if len(buf) == 0: # Connection was closed.
+                if len(buf) == 0:  # Connection was closed.
                     raise SerfConnectionError("Connection closed by peer")
                 unpacker.feed(buf)
             except socket.timeout:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -100,7 +100,6 @@ class TestSerfConnection(object):
         with pytest.raises(connection.SerfProtocolError):
             rpc.call('members')
 
-
     def test_connection_closed(self, rpc):
         rpc.handshake()
 


### PR DESCRIPTION
If a user makes a serf RPC call, stops serf, makes another RPC call, this one will spin forever calling socket.recv. Each call to socket.recv will return an empty string, which we should detect and use to raise a connection error.

Comes with a test several times longer. :)
