### PR TITLE
Fixing dependency on serfclient.__version__ in setup.py

### DIFF
--- a/serfclient/__init__.py
+++ b/serfclient/__init__.py
@@ -1,3 +1,5 @@
-__version__ = '0.3.0'
+from pkg_resources import get_distribution
+
+__version__ = get_distribution('serfclient').version
 
 from serfclient.client import SerfClient

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-from serfclient import __version__
-
 try:
     from setuptools import setup
     from setuptools.command.test import test as TestCommand
@@ -30,7 +28,7 @@ except:
 
 setup(
     name='serfclient',
-    version=__version__,
+    version='0.3.0',
     description='Python client for the Serf orchestration tool',
     long_description=long_description,
     url='https://github.com/KushalP/serfclient-py',


### PR DESCRIPTION
The current setup.py attempts to import serfclient to get the __version__. However at this point serfclient hasn't been installed yet. You can't install serfclient with the setup.py without already having its dependencies (msgpack-python) installed or that import will fail. A "pip install serfclient" fails out of the box unless you first install msgpack-python.