### PR TITLE
Test against the latest release of Serf (v0.6.4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "2.7"
   - "2.6"
 before_install:
-  - wget https://dl.bintray.com/mitchellh/serf/0.5.0_linux_amd64.zip
-  - unzip 0.5.0_linux_amd64.zip
+  - wget https://dl.bintray.com/mitchellh/serf/0.6.4_linux_amd64.zip
+  - unzip 0.6.4_linux_amd64.zip
   - ./serf agent &
   - sleep 1 ; ./serf tags -set foo=bar
 install:

--- a/serfclient/__init__.py
+++ b/serfclient/__init__.py
@@ -1,5 +1,4 @@
 from pkg_resources import get_distribution
+from serfclient.client import SerfClient
 
 __version__ = get_distribution('serfclient').version
-
-from serfclient.client import SerfClient


### PR DESCRIPTION
Make sure that we're tracking the latest stable version instead of an
older version that some of the users libraries might not be using any
longer.