### PR TITLE
Use SERF_RPC_ADDR env var, if set

### DIFF
--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -1,13 +1,24 @@
+import os
+
 try:
     from serfclient.connection import SerfConnection
 except ImportError:
     from connection import SerfConnection
 
 
+def _get_env_host_and_port():
+    env_host, env_port = None, None
+    serf_rpc_addr = os.getenv('SERF_RPC_ADDR')
+    if serf_rpc_addr:
+        env_host, env_port = serf_rpc_addr.split(':')
+    return env_host, env_port
+
+
 class SerfClient(object):
-    def __init__(self, host='localhost', port=7373, timeout=3):
-        self.host = host
-        self.port = port
+    def __init__(self, host=None, port=None, timeout=3):
+        env_host, env_port = _get_env_host_and_port()
+        self.host = host or env_host or 'localhost'
+        self.port = port or env_port or 7373
         self.timeout = timeout
         self.connection = SerfConnection(
             host=self.host, port=self.port, timeout=self.timeout)

--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -14,8 +14,12 @@ def _get_env_host_and_port():
     return env_host, env_port
 
 
+def _get_env_rpc_auth():
+    return os.getenv('SERF_RPC_AUTH')
+
+
 class SerfClient(object):
-    def __init__(self, host=None, port=None, timeout=3):
+    def __init__(self, host=None, port=None, rpc_auth=None, timeout=3):
         env_host, env_port = _get_env_host_and_port()
         self.host = host or env_host or 'localhost'
         self.port = port or env_port or 7373
@@ -23,6 +27,10 @@ class SerfClient(object):
         self.connection = SerfConnection(
             host=self.host, port=self.port, timeout=self.timeout)
         self.connection.handshake()
+        env_rpc_auth = _get_env_rpc_auth()
+        self.rpc_auth = rpc_auth or env_rpc_auth or None
+        if self.rpc_auth:
+            self.connection.auth(self.rpc_auth)
 
     def event(self, name, payload=None, coalesce=True):
         """

--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -107,6 +107,14 @@ class SerfConnection(object):
             self._socket = self._connect()
         return self.call('handshake', {"Version": 1}, expect_body=False)
 
+    def auth(self, auth_key):
+        """
+        Performs the initial authentication on connect
+        """
+        if self._socket is None:
+            self._socket = self._connect()
+        return self.call('auth', {"AuthKey": auth_key}, expect_body=False)
+
     def _connect(self):
         try:
             return socket.create_connection(


### PR DESCRIPTION
This allows using the `SERF_RPC_ADDR` environment variable, that is already understood by Serf (see https://www.serfdom.io/docs/commands/members.html#_rpc_addr).

Cc: @sudarkoff, @bcoca