### PR TITLE
Add rpc_auth parameter to SerfClient.__init__

### DIFF
--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -5,13 +5,15 @@ except ImportError:
 
 
 class SerfClient(object):
-    def __init__(self, host='localhost', port=7373, timeout=3):
+    def __init__(self, host='localhost', port=7373, rpc_auth=None, timeout=3):
         self.host = host
         self.port = port
         self.timeout = timeout
         self.connection = SerfConnection(
             host=self.host, port=self.port, timeout=self.timeout)
         self.connection.handshake()
+        if rpc_auth:
+            self.connection.auth(rpc_auth)
 
     def event(self, name, payload=None, coalesce=True):
         """

--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -107,6 +107,14 @@ class SerfConnection(object):
             self._socket = self._connect()
         return self.call('handshake', {"Version": 1}, expect_body=False)
 
+    def auth(self, auth_key):
+        """
+        Performs the initial authentication on connect
+        """
+        if self._socket is None:
+            self._socket = self._connect()
+        return self.call('auth', {"AuthKey": auth_key}, expect_body=False)
+
     def _connect(self):
         try:
             return socket.create_connection(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from serfclient import client
@@ -10,6 +11,13 @@ class TestSerfClientCommands(object):
     @pytest.fixture
     def serf(self):
         return client.SerfClient()
+
+    @mock.patch('serfclient.client.SerfConnection')
+    def test_rpc_auth(self, mock_serf_connection_class):
+        mock_serf_connection = mock.MagicMock()
+        mock_serf_connection_class.return_value = mock_serf_connection
+        serf = client.SerfClient(rpc_auth='secret')
+        mock_serf_connection.auth.assert_called_once_with('secret')
 
     def test_has_a_default_host_and_port(self, serf):
         assert serf.host == 'localhost'

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26, py27
 
 [testenv]
 deps =
+    mock
     msgpack-python
     pytest
 commands = py.test


### PR DESCRIPTION
This allows passing an RPC auth token, as described at
https://www.serfdom.io/docs/commands/members.html#_rpc_auth

This replaces #11.