### PR TITLE
Tox enhancements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py26, py27, py32, py33, py34
 deps =
     msgpack-python
     pytest
-commands = py.test
+commands = {posargs:py.test}


### PR DESCRIPTION
A few `tox.ini` enhancements

- Add `py32, py33, py34` to `envlist`

- Use `{posargs}` for commands

  Lets you pass args to `py.test` like:

   ```
   tox -e py27 -- py.test --pdb --durations=10 tests/test_connection.py
   ```

    or even execute a totally different command like:

        tox -e py27 -- pip freeze

    By default, it simply calls `py.test`, as it did before.