### PR TITLE
Flake8

### DIFF
--- a/serfclient/__init__.py
+++ b/serfclient/__init__.py
@@ -2,3 +2,5 @@ from pkg_resources import get_distribution
 from serfclient.client import SerfClient
 
 __version__ = get_distribution('serfclient').version
+
+__all__ = ['SerfClient']

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,5 +1,3 @@
-import pytest
-
 from serfclient import result
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,8 @@ deps =
     msgpack-python
     pytest
 commands = {posargs:py.test}
+
+[testenv:flake8]
+deps =
+    flake8
+commands = {posargs:flake8 serfclient tests}


### PR DESCRIPTION
Adds a `flake8` tox target and then fixes the 2 warnings that are reported.

```
$ tox -e flake8
GLOB sdist-make: /Users/marca/dev/git-repos/serfclient-py/setup.py
flake8 inst-nodeps: /Users/marca/dev/git-repos/serfclient-py/.tox/dist/serfclient-0.4.0.zip
flake8 runtests: PYTHONHASHSEED='3872156782'
flake8 runtests: commands[0] | flake8 serfclient tests
___________________________________________________________________________________ summary ____________________________________________________________________________________
  flake8: commands succeeded
  congratulations :)
```