### PR TITLE
Add EnvironmentConfig class

### DIFF
--- a/serfclient/__init__.py
+++ b/serfclient/__init__.py
@@ -1,6 +1,7 @@
 from pkg_resources import get_distribution
 from serfclient.client import SerfClient
+from serfclient.environment_config import EnvironmentConfig
 
 __version__ = get_distribution('serfclient').version
 
-__all__ = ['SerfClient']
+__all__ = ['SerfClient', 'EnvironmentConfig']

--- a/serfclient/environment_config.py
+++ b/serfclient/environment_config.py
@@ -1,0 +1,33 @@
+import os
+
+
+class EnvironmentConfig(object):
+    """
+    Reads environment variables that Serf understands and parses
+    them into a easily consumable object.
+
+    Currently supports reading the following environment variables:
+
+     - SERF_RPC_AUTH
+     - SERF_RPC_ADDR
+
+    and sets attributes:
+
+     - host
+     - port
+     - auth_key
+    """
+
+    def __init__(self):
+        self.host = 'localhost'
+        self.port = 7373
+        self.auth_key = None
+
+        rpc_addr = os.getenv('SERF_RPC_ADDR')
+        if rpc_addr:
+            self.host, self.port = rpc_addr.split(':')
+            self.port = int(self.port)
+
+        rpc_auth = os.getenv('SERF_RPC_AUTH')
+        if rpc_auth:
+            self.auth_key = rpc_auth

--- a/tests/test_environmentconfig.py
+++ b/tests/test_environmentconfig.py
@@ -1,0 +1,44 @@
+import mock
+
+from serfclient import EnvironmentConfig
+
+
+@mock.patch('os.getenv')
+def test_defaults(os_getenv):
+    os_getenv.return_value = None
+
+    env = EnvironmentConfig()
+
+    assert env.host == 'localhost'
+    assert env.port == 7373
+    assert env.auth_key is None
+
+
+@mock.patch('os.getenv')
+def test_serf_rpc_addr(os_getenv):
+    def fake_os_getenv(key, default=None):
+        if key == 'SERF_RPC_ADDR':
+            return 'serf.company.com:6464'
+
+    os_getenv.side_effect = fake_os_getenv
+
+    env = EnvironmentConfig()
+
+    assert env.host == 'serf.company.com'
+    assert env.port == 6464
+    assert env.auth_key is None
+
+
+@mock.patch('os.getenv')
+def test_serf_rpc_auth(os_getenv):
+    def fake_os_getenv(key, default=None):
+        if key == 'SERF_RPC_AUTH':
+            return 'secret'
+
+    os_getenv.side_effect = fake_os_getenv
+
+    env = EnvironmentConfig()
+
+    assert env.host == 'localhost'
+    assert env.port == 7373
+    assert env.auth_key == 'secret'


### PR DESCRIPTION
Fixes: GH-16
Also takes care of the environment variable stuff I was trying to address in #11, but does it in a cleaner way.

```
$ SERF_RPC_ADDR=serf.company.com:6464 SERF_RPC_AUTH="secret" ipython
Python 2.7.9 (v2.7.9:648dcafa7e5f, Dec 10 2014, 10:10:46)
Type "copyright", "credits" or "license" for more information.

IPython 2.0.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from serfclient import EnvironmentConfig

In [2]: environment = EnvironmentConfig()

In [3]: environment.host
Out[3]: 'serf.company.com'

In [4]: environment.port
Out[4]: 6464

In [5]: environment.auth_key
Out[5]: 'secret'
```