### PR TITLE
Fix flake8 warning

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,7 @@ class TestSerfClientCommands(object):
         mock_serf_connection = mock.MagicMock()
         mock_serf_connection_class.return_value = mock_serf_connection
         serf = client.SerfClient(rpc_auth='secret')
+        assert serf.connection is not None
         mock_serf_connection.auth.assert_called_once_with('secret')
 
     def test_has_a_default_host_and_port(self, serf):


### PR DESCRIPTION
Fixes this flake8 warning that I introduced in 1970c14:

    tests/test_client.py:19:9: F841 local variable 'serf' is assigned to but never used

```
$ tox -e flake8
GLOB sdist-make: /Users/marca/dev/git-repos/serfclient-py/setup.py
flake8 inst-nodeps: /Users/marca/dev/git-repos/serfclient-py/.tox/dist/serfclient-0.4.0.zip
flake8 runtests: PYTHONHASHSEED='744612590'
flake8 runtests: commands[0] | flake8 serfclient tests
___________________________________________________________________________________ summary ____________________________________________________________________________________
  flake8: commands succeeded
  congratulations :)
```