### PR TITLE
Add stats command

### DIFF
--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -68,3 +68,9 @@ class SerfClient(object):
         return self.connection.call(
             'join',
             {"Existing": location, "Replay": False})
+
+    def stats(self):
+        """
+        Obtain operator debugging information about the running Serf agent.
+        """
+        return self.connection.call('stats')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,3 +100,9 @@ class TestSerfClientCommands(object):
         ip_addr = members.body[b'Members'][0][b'Addr']
 
         assert re.match(b'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', ip_addr)
+
+    def test_stats_is_well_formed(self, serf):
+        stats = serf.stats()
+        for key in [b'agent', b'runtime', b'serf', b'tags']:
+            assert key in stats.body
+            assert isinstance(stats.body[key], dict)


### PR DESCRIPTION
This adds the super simple `stats` command, which takes no args and is documented here: https://www.serfdom.io/docs/agent/rpc.html

This is the RPC equivalent of `serf info`.