### PR TITLE
Peg Coverage to versions which work with Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - pip install msgpack-python
   - pip install -e . --use-mirrors
-  - pip install coverage coveralls pep8
+  - pip install 'coverage<4.0.0' coveralls pep8
 script:
   - coverage run --source=serfclient setup.py test
   - coverage report -m


### PR DESCRIPTION
Coverage 4.0.0 breaks support for Python 3.2, which serfclient supports

As you can see [here](https://pypi.python.org/pypi/coverage), the list of supported versions no longer includes Python 3.2.