### PR TITLE
Fix issue #24: Modify decoder to parser packed IPv6 as well as IPv4 address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - "2.7"
   - "2.6"
 before_install:
-  - wget https://dl.bintray.com/mitchellh/serf/0.6.4_linux_amd64.zip
-  - unzip 0.6.4_linux_amd64.zip
+  - wget https://releases.hashicorp.com/serf/0.6.4/serf_0.6.4_linux_amd64.zip
+  - unzip serf_0.6.4_linux_amd64.zip
   - ./serf agent &
   - sleep 1 ; ./serf tags -set foo=bar
 install:

--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -149,13 +149,20 @@ class SerfConnection(object):
         """
         key = b'Addr'
         if key in obj_dict:
-            ip_addr = socket.inet_ntop(socket.AF_INET6, obj_dict[key])
+            try:
+                # Try to convert a packed IPv6 address.
+                # Note: Call raises ValueError if address is actually IPv4.
+                ip_addr = socket.inet_ntop(socket.AF_INET6, obj_dict[key])
 
-            # Check if the address is an IPv4 mapped IPv6 address:
-            # ie. ::ffff:xxx.xxx.xxx.xxx
-            if ip_addr.startswith('::ffff:'):
-                ip_addr = ip_addr.lstrip('::ffff:')
+                # Check if the address is an IPv4 mapped IPv6 address:
+                # ie. ::ffff:xxx.xxx.xxx.xxx
+                if ip_addr.startswith('::ffff:'):
+                    ip_addr = ip_addr.lstrip('::ffff:')
 
-            obj_dict[key] = ip_addr.encode('utf-8')
+                obj_dict[key] = ip_addr.encode('utf-8')
+            except ValueError:
+                # Try to convert a packed IPv4 address.
+                ip_addr = socket.inet_ntop(socket.AF_INET, obj_dict[key])
+                obj_dict[key] = ip_addr.encode('utf-8')
 
         return obj_dict

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,5 @@
 import pytest
+import socket
 import time
 
 from serfclient import connection
@@ -116,3 +117,24 @@ class TestSerfConnection(object):
 
         with pytest.raises(connection.SerfConnectionError):
             rpc.handshake()
+
+    def test_decode_addr_key_ipv6(self, rpc):
+        key = b'Addr'
+        ip_addr = '2001:a:b:c:1:2:3:4'
+        dict = {key: socket.inet_pton(socket.AF_INET6, ip_addr)}
+        result = rpc._decode_addr_key(dict)
+        assert result[key].decode('utf-8') == ip_addr
+
+    def test_decode_addr_key_ipv4_mapped_ipv6(self, rpc):
+        key = b'Addr'
+        ip_addr = '::ffff:192.168.0.1'
+        dict = {key: socket.inet_pton(socket.AF_INET6, ip_addr)}
+        result = rpc._decode_addr_key(dict)
+        assert result[key].decode('utf-8') == '192.168.0.1'
+
+    def test_decode_addr_key_ipv4(self, rpc):
+        key = b'Addr'
+        ip_addr = '192.168.0.1'
+        dict = {key: socket.inet_pton(socket.AF_INET, ip_addr)}
+        result = rpc._decode_addr_key(dict)
+        assert result[key].decode('utf-8') == ip_addr


### PR DESCRIPTION
Fix issue #24 
- first: try to parse 'Addr' as packed IPv6
- if failed: try to parser 'Addr' as packed IPv4

Unfortunately, I cannot reproduce the problem when I use the serf agent as normal. Therefore, I added some unit tests instead. Hopefully it will simulate the possible conditions.

Note: I also updated the link to serf client as the previous link no longer works and breaks TravisCI.