### PR TITLE
Fix #29 - Expose a shutdown() for SerfClient.

### DIFF
--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -75,10 +75,10 @@ class SerfClient(object):
         """
         return self.connection.call('stats')
 
-    def shutdown(self):
+    def close(self):
         """
-        Shutdown and cleanup open connections to Serf agent.
+        Close connection to Serf agent.
         """
         if self.connection:
-            self.connection.disconnect()
+            self.connection.close()
             self.connection = None

--- a/serfclient/client.py
+++ b/serfclient/client.py
@@ -74,3 +74,11 @@ class SerfClient(object):
         Obtain operator debugging information about the running Serf agent.
         """
         return self.connection.call('stats')
+
+    def shutdown(self):
+        """
+        Shutdown and cleanup open connections to Serf agent.
+        """
+        if self.connection:
+            self.connection.disconnect()
+            self.connection = None

--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -166,3 +166,11 @@ class SerfConnection(object):
                 obj_dict[key] = ip_addr.encode('utf-8')
 
         return obj_dict
+
+    def disconnect(self):
+        """
+        Disconnect the connection with the Serf agent.
+        """
+        if self._socket:
+            self._socket.close()
+            self._socket = None

--- a/serfclient/connection.py
+++ b/serfclient/connection.py
@@ -167,9 +167,9 @@ class SerfConnection(object):
 
         return obj_dict
 
-    def disconnect(self):
+    def close(self):
         """
-        Disconnect the connection with the Serf agent.
+        Close the connection with the Serf agent.
         """
         if self._socket:
             self._socket.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -111,7 +111,7 @@ class TestSerfClientCommands(object):
             assert key in stats.body
             assert isinstance(stats.body[key], dict)
 
-    def test_shutdown(self, serf):
+    def test_close(self, serf):
         assert serf.connection is not None
-        serf.shutdown()
+        serf.close()
         assert serf.connection is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,3 +110,8 @@ class TestSerfClientCommands(object):
         for key in [b'agent', b'runtime', b'serf', b'tags']:
             assert key in stats.body
             assert isinstance(stats.body[key], dict)
+
+    def test_shutdown(self, serf):
+        assert serf.connection is not None
+        serf.shutdown()
+        assert serf.connection is None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -134,3 +134,9 @@ class TestSerfConnection(object):
     def test_decode_addr_key_ipv4(self, rpc):
         ip_address = '192.168.0.1'
         assert extract_addr(rpc, ip_address, socket.AF_INET) == ip_address
+
+    def test_disconnect(self, rpc):
+        rpc.handshake()
+        assert rpc._socket is not None
+        rpc.disconnect()
+        assert rpc._socket is None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -135,8 +135,8 @@ class TestSerfConnection(object):
         ip_address = '192.168.0.1'
         assert extract_addr(rpc, ip_address, socket.AF_INET) == ip_address
 
-    def test_disconnect(self, rpc):
+    def test_close(self, rpc):
         rpc.handshake()
         assert rpc._socket is not None
-        rpc.disconnect()
+        rpc.close()
         assert rpc._socket is None


### PR DESCRIPTION
After SerfClient is initialized, it holds a reference to SerfConnection object, which holds an internal reference to socket. When the SerfClient is no longer required, any resource acquired should be released.

Reference:
https://docs.python.org/2/howto/sockets.html#disconnecting