### PR TITLE
Change msgpack-python requirement to msgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords=['Serf', 'orchestration', 'service discovery'],
     license='MIT',
     packages=['serfclient'],
-    install_requires=['msgpack-python >= 0.4.0'],
+    install_requires=['msgpack >= 0.5.0'],
     tests_require=test_requires,
     cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
This package has been renamed to `msgpack` starting with their `0.5.0` version. The old package seems likely to be deprecated soon, but this change will keep the dependency being updated as intended.

https://pypi.python.org/pypi/msgpack
https://pypi.python.org/pypi/msgpack-python